### PR TITLE
upgraded _keras_unstack_hack to handle arbitrary data size

### DIFF
--- a/python/wtte/wtte.py
+++ b/python/wtte/wtte.py
@@ -10,26 +10,13 @@ def _keras_unstack_hack(ab):
        Keras-hack adopted to be compatible with theano backend.
     """
     ndim = len(K.int_shape(ab))
-    if ndim==0:
+    if ndim == 0:
         print('can not unstack with ndim=0')
-    elif ndim==2:
-        a = ab[0]
-        b = ab[1]
-    elif ndim==2:
-        a = ab[:,0]
-        b = ab[:,1]
-    elif ndim==3:
-        a = ab[:,:,0]
-        b = ab[:,:,1]
-    elif ndim==4:
-        a = ab[:,:,:,0]
-        b = ab[:,:,:,1]
-    elif ndim==5:
-        a = ab[:,:,:,:,0]
-        b = ab[:,:,:,:,1]
     else:
-        print('ndim >5 not yet implemented')
-    return a,b
+        slices = (slice(None),) * (ndim-1)
+        a = ab[(*slices, 0)]
+        b = ab[(*slices, 1)]
+    return a, b
 
 def output_lambda(x,init_alpha=1.0, max_beta_value=5.0):
     """Elementwise (Lambda) computation of alpha and regularized beta.


### PR DESCRIPTION
I upgraded the `_keras_unstack_hack` so that it doesn't require explicit implementations for each number of dimensions.

Also, I was holding off on committing this in, but `pep8` should be run on the codebase! There are some files that use python3 syntax and some that use python3.